### PR TITLE
fix scikit-image version 0.0 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,4 @@ torch==2.4.1
 torchvision==0.19.1
 tqdm==4.66.5
 seaborn==0.13.2
-python-dotenv
 wandb


### PR DESCRIPTION
ERROR: No matching distribution found for scikit-image==0.0 fix